### PR TITLE
Upgrade to ast-types v0.4.1 and update tests to use new features.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,11 +265,16 @@ function getGlobals(ast) {
   var globals = [];
   var seen = Object.create(null);
 
-  types.traverse(ast, function(node) {
-    if (isReference(this) && !this.scope.lookup(node.name)) {
-      if (!(node.name in seen)) {
-        seen[node.name] = true;
-        globals.push(node);
+  types.visit(ast, {
+    visitNode: function(path) {
+      this.traverse(path);
+      var node = path.value;
+
+      if (isReference(path) && !path.scope.lookup(node.name)) {
+        if (!(node.name in seen)) {
+          seen[node.name] = true;
+          globals.push(node);
+        }
       }
     }
   });
@@ -352,12 +357,11 @@ function injectVariable(scope, identifier, init) {
     bodyPath = bodyPath.get('body');
   }
 
-  bodyPath.get(0).replace(
+  bodyPath.unshift(
     b.variableDeclaration(
       'var',
       [b.variableDeclarator(identifier, init || null)]
-    ),
-    bodyPath.get(0).value
+    )
   );
 
   // Ensure this identifier counts as used in this scope.

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "homepage": "https://github.com/square/ast-util",
   "devDependencies": {
     "mocha": "^1.18.2",
-    "recast": "^0.5.16",
+    "recast": "^0.6.2",
     "esprima": "git://github.com/ariya/esprima.git#harmony"
   },
   "dependencies": {
-    "ast-types": "^0.3.26",
-    "private": "^0.1.3"
+    "ast-types": "^0.4.1",
+    "private": "^0.1.5"
   }
 }


### PR DESCRIPTION
Key new features: `Path.prototype.unshift` (and friends: `shift`, `push`, `pop`, `insertAt`, `insertBefore`, `insertAfter`) and `types.visit` (which replaces `types.traverse`).
