### PR TITLE
Add `.gitignore` to prevent git & git UI tools to list all /node_modules/... files as 'unchecked' 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# NodeJS/NPM packages:
+/node_modules/
+


### PR DESCRIPTION
these are installed / created by `npm install` after all, so there's no need for git to see these.