### PR TITLE
fix license for modern NPM SPDX requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "macros"
   ],
   "author": "Brian Donovan",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/eventualbuddha/ast-util/issues"
   },


### PR DESCRIPTION
as per https://spdx.org/licenses/Apache-2.0